### PR TITLE
Sign.

### DIFF
--- a/computable/contracts/datatrust.py
+++ b/computable/contracts/datatrust.py
@@ -9,26 +9,26 @@ class Datatrust(Deployed):
         @param listing Address
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('setPrivileged')}, opts)
-        return self.deployed.functions.setPrivileged(listing).transact(opts)
+        return self.deployed.functions.setPrivileged(listing), opts
 
     def get_privileged(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getPrivileged')}, opts)
-        return self.deployed.functions.getPrivileged().call(opts)
+        return self.deployed.functions.getPrivileged(), opts
 
     def get_hash(self, url, opts=None):
         """
         @param url String (max 128 chars) which is the url of a datatrust
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('getHash')}, opts)
-        return self.deployed.functions.getHash(url).call(opts)
+        return self.deployed.functions.getHash(url), opts
 
     def get_backend_address(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getBackendAddress')}, opts)
-        return self.deployed.functions.getBackendAddress().call(opts)
+        return self.deployed.functions.getBackendAddress(), opts
 
     def get_backend_url(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getBackendUrl')}, opts)
-        return self.deployed.functions.getBackendUrl().call(opts)
+        return self.deployed.functions.getBackendUrl(), opts
 
     def set_backend_url(self, url, opts=None):
         """
@@ -36,7 +36,7 @@ class Datatrust(Deployed):
         @param url String (max 128 chars) which is the url of a datatrust
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('setBackendUrl')}, opts)
-        return self.deployed.functions.setBackendUrl(url).transact(opts)
+        return self.deployed.functions.setBackendUrl(url), opts
 
     def set_data_hash(self, listing, data, opts=None):
         """
@@ -44,39 +44,39 @@ class Datatrust(Deployed):
         @param data A keccack256 hash of the actual data for said listing
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('setDataHash')}, opts)
-        return self.deployed.functions.setDataHash(listing, data).transact(opts)
+        return self.deployed.functions.setDataHash(listing, data), opts
 
     def register(self, url, opts=None):
         """
         @param url String (max 128 chars) which is the url of a datatrust
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('register')}, opts)
-        return self.deployed.functions.register(url).transact(opts)
+        return self.deployed.functions.register(url), opts
 
     def resolve_registration(self, hash, opts=None):
         """
         @param hash Keccack256 hash of the registration candidate's URL
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('resolveRegistration')}, opts)
-        return self.deployed.functions.resolveRegistration(hash).transact(opts)
+        return self.deployed.functions.resolveRegistration(hash), opts
 
     def request_delivery(self, hash, amount, opts=None):
         """
         @param hash Keccack256 hash of a delivery-query recieved from a demand buyer
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('requestDelivery')}, opts)
-        return self.deployed.functions.requestDelivery(hash, amount).transact(opts)
+        return self.deployed.functions.requestDelivery(hash, amount), opts
 
     def get_bytes_purchased(self, addr, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getBytesPurchased')}, opts)
-        return self.deployed.functions.getBytesPurchased(addr).call(opts)
+        return self.deployed.functions.getBytesPurchased(addr), opts
 
     def get_delivery(self, hash, opts=None):
         """
         @return (owner, bytes_requested, bytes_delivered)
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('getDelivery')}, opts)
-        return self.deployed.functions.getDelivery(hash).call(opts)
+        return self.deployed.functions.getDelivery(hash), opts
 
     def listing_accessed(self, listing, delivery, amount, opts=None):
         """
@@ -85,7 +85,7 @@ class Datatrust(Deployed):
         @param amount Number of bytes accessed from said listing
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('listingAccessed')}, opts)
-        return self.deployed.functions.listingAccessed(listing, delivery, amount).transact(opts)
+        return self.deployed.functions.listingAccessed(listing, delivery, amount), opts
 
     def get_bytes_accessed(self, hash, opts=None):
         """
@@ -93,7 +93,7 @@ class Datatrust(Deployed):
         @param hash Keccack256 hash Listing identifier
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('getBytesAccessed')}, opts)
-        return self.deployed.functions.getBytesAccessed(hash).call(opts)
+        return self.deployed.functions.getBytesAccessed(hash), opts
 
     def delivered(self, delivery, url, opts=None):
         """
@@ -102,4 +102,4 @@ class Datatrust(Deployed):
         """
         # TODO we could check length of the url here and raise...
         opts = self.assign_transact_opts({'gas': self.get_gas('delivered')}, opts)
-        return self.deployed.functions.delivered(delivery, url).transact(opts)
+        return self.deployed.functions.delivered(delivery, url), opts

--- a/computable/contracts/deployed.py
+++ b/computable/contracts/deployed.py
@@ -25,11 +25,12 @@ class Deployed:
             src.update(opts)
         return src
 
-    def at(self, w3, address, filename):
+    def at(self, w3, address, filename, chain_id=None):
         """
         @param w3 An instance of Web3
         @param address EVM address of a deployed contract
         @param filename Name (with extension) of an abi file to read.
+        @param chain_id Identifier of the block chain this contract is one (or None)
         NOTE: We expect the file to be read to be a sibling to this file (same dir)
         """
         abi = None
@@ -48,6 +49,13 @@ class Deployed:
         self.address = address
         # remember the abi so we can fetch gas prices from it
         self.abi = abi
+        # set the passed in chainId or default
+        self.chain_id = chain_id
+
+    def extend_transact_opts(self, w3, opts):
+        opts['nonce'] = w3.eth.getTransactionCount(opts['from'])
+        opts['chainId'] = self.chain_id
+        return opts
 
     def get_gas(self, method):
         """

--- a/computable/contracts/deployed.py
+++ b/computable/contracts/deployed.py
@@ -10,6 +10,8 @@ class Deployed:
         class instance
         """
         self.account = acct
+        # default the chain_id to None
+        self.chain_id = None
 
     def assign_transact_opts(self, src, opts=None):
         """
@@ -18,8 +20,10 @@ class Deployed:
         """
         if 'from' not in src:
             src['from'] = self.account
-        if 'gas_price' not in src:
-            src['gas_price'] = GAS_PRICE
+        if 'gasPrice' not in src:
+            src['gasPrice'] = GAS_PRICE
+        if 'chainId' not in src:
+            src['chainId'] = self.chain_id
 
         if opts is not None:
             src.update(opts)
@@ -30,8 +34,7 @@ class Deployed:
         @param w3 An instance of Web3
         @param address EVM address of a deployed contract
         @param filename Name (with extension) of an abi file to read.
-        @param chain_id Identifier of the block chain this contract is one (or None)
-        NOTE: We expect the file to be read to be a sibling to this file (same dir)
+        @param chain_id Identifier of the block chain `address` is on (or None)
         """
         abi = None
         path = os.path.join(os.path.dirname(__file__), filename)
@@ -49,13 +52,9 @@ class Deployed:
         self.address = address
         # remember the abi so we can fetch gas prices from it
         self.abi = abi
-        # set the passed in chainId or default
-        self.chain_id = chain_id
-
-    def extend_transact_opts(self, w3, opts):
-        opts['nonce'] = w3.eth.getTransactionCount(opts['from'])
-        opts['chainId'] = self.chain_id
-        return opts
+        # set the passed in chainId if present
+        if chain_id is not None:
+            self.chain_id = chain_id
 
     def get_gas(self, method):
         """

--- a/computable/contracts/erc20.py
+++ b/computable/contracts/erc20.py
@@ -3,32 +3,32 @@ from computable.contracts.deployed import Deployed
 class ERC20(Deployed):
     def allowance(self, owner, spender, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('allowance')}, opts)
-        return self.deployed.functions.allowance(owner, spender).call(opts)
+        return self.deployed.functions.allowance(owner, spender), opts
 
     def approve(self, spender, amount, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('approve')}, opts)
-        return self.deployed.functions.approve(spender, amount).transact(opts)
+        return self.deployed.functions.approve(spender, amount), opts
 
     def balance_of(self, owner, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('balanceOf')}, opts)
-        return self.deployed.functions.balanceOf(owner).call(opts)
+        return self.deployed.functions.balanceOf(owner), opts
 
     def decrease_approval(self, spender, amount, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('decreaseApproval')}, opts)
-        return self.deployed.functions.decreaseApproval(spender, amount).transact(opts)
+        return self.deployed.functions.decreaseApproval(spender, amount), opts
 
     def increase_approval(self, spender, amount, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('increaseApproval')}, opts)
-        return self.deployed.functions.increaseApproval(spender, amount).transact(opts)
+        return self.deployed.functions.increaseApproval(spender, amount), opts
 
     def total_supply(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('totalSupply')}, opts)
-        return self.deployed.functions.totalSupply().call(opts)
+        return self.deployed.functions.totalSupply(), opts
 
     def transfer(self, to, amount, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('transfer')}, opts)
-        return self.deployed.functions.transfer(to, amount).transact(opts)
+        return self.deployed.functions.transfer(to, amount), opts
 
     def transfer_from(self, source, to, amount, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('transferFrom')}, opts)
-        return self.deployed.functions.transferFrom(source, to, amount).transact(opts)
+        return self.deployed.functions.transferFrom(source, to, amount), opts

--- a/computable/contracts/ether_token.py
+++ b/computable/contracts/ether_token.py
@@ -10,7 +10,7 @@ class EtherToken(ERC20):
         @param opts Transact Opts for this send type method
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('deposit'), 'value': amount}, opts)
-        return self.deployed.functions.deposit().transact(opts)
+        return self.deployed.functions.deposit(), opts
 
     def withdraw(self, amount, opts=None):
         """
@@ -18,4 +18,4 @@ class EtherToken(ERC20):
         by its owner
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('withdraw')}, opts)
-        return self.deployed.functions.withdraw(amount).transact(opts)
+        return self.deployed.functions.withdraw(amount), opts

--- a/computable/contracts/investing.py
+++ b/computable/contracts/investing.py
@@ -6,16 +6,16 @@ class Investing(Deployed):
 
     def get_investment_price(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getInvestmentPrice')}, opts)
-        return self.deployed.functions.getInvestmentPrice().call(opts)
+        return self.deployed.functions.getInvestmentPrice(), opts
 
     def invest(self, offer, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('invest')}, opts)
-        return self.deployed.functions.invest(offer).transact(opts)
+        return self.deployed.functions.invest(offer), opts
 
     def get_divestment_proceeds(sef, addr, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getDivestmentProceeds')}, opts)
-        return self.deployed.functions.getDivestmentProceeds(addr).call(opts)
+        return self.deployed.functions.getDivestmentProceeds(addr), opts
 
     def divest():
         opts = self.assign_transact_opts({'gas': self.get_gas('divest')}, opts)
-        return self.deployed.functions.divest().transact(opts)
+        return self.deployed.functions.divest(), opts

--- a/computable/contracts/listing.py
+++ b/computable/contracts/listing.py
@@ -6,39 +6,39 @@ class Listing(Deployed):
 
     def is_listed(self, hash, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('isListed')}, opts)
-        return self.deployed.functions.isListed(hash).call(opts)
+        return self.deployed.functions.isListed(hash), opts
 
     def withdraw_from_listing(self, hash, amount, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('withdrawFromListing')}, opts)
-        return self.deployed.functions.withdrawFromListing(hash, amount).transact(opts)
+        return self.deployed.functions.withdrawFromListing(hash, amount), opts
 
     def list(self, hash, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('list')}, opts)
-        return self.deployed.functions.list(hash).transact(opts)
+        return self.deployed.functions.list(hash), opts
 
     def get_listing(self, hash, opts=None):
         """
         @return (owner, supply)
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('getListing')}, opts)
-        return self.deployed.functions.getListing(hash).call(opts)
+        return self.deployed.functions.getListing(hash), opts
 
     def resolve_application(self, hash, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('resolveApplication')}, opts)
-        return self.deployed.functions.resolveApplication(hash).transact(opts)
+        return self.deployed.functions.resolveApplication(hash), opts
 
     def claim_bytes_accessed(self, hash, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('claimBytesAccessed')}, opts)
-        return self.deployed.functions.claimBytesAccessed(hash).transact(opts)
+        return self.deployed.functions.claimBytesAccessed(hash), opts
 
     def challenge(self, hash, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('challenge')}, opts)
-        return self.deployed.functions.challenge(hash).transact(opts)
+        return self.deployed.functions.challenge(hash), opts
 
     def resolve_challenge(self, hash, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('resolveChallenge')}, opts)
-        return self.deployed.functions.resolveChallenge(hash).transact(opts)
+        return self.deployed.functions.resolveChallenge(hash), opts
 
     def exit(self, hash, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('exit')}, opts)
-        return self.deployed.functions.exit(hash).transact(opts)
+        return self.deployed.functions.exit(hash), opts

--- a/computable/contracts/parameterizer.py
+++ b/computable/contracts/parameterizer.py
@@ -6,27 +6,27 @@ class Parameterizer(Deployed):
 
     def get_backend_payment(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getBackendPayment')}, opts)
-        return self.deployed.functions.getBackendPayment().call(opts)
+        return self.deployed.functions.getBackendPayment(), opts
 
     def get_maker_payment(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getMakerPayment')}, opts)
-        return self.deployed.functions.getMakerPayment().call(opts)
+        return self.deployed.functions.getMakerPayment(), opts
 
     def get_reserve_payment(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getReservePayment')}, opts)
-        return self.deployed.functions.getReservePayment().call(opts)
+        return self.deployed.functions.getReservePayment(), opts
 
     def get_cost_per_byte(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getCostPerByte')}, opts)
-        return self.deployed.functions.getCostPerByte().call(opts)
+        return self.deployed.functions.getCostPerByte(), opts
 
     def get_stake(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getStake')}, opts)
-        return self.deployed.functions.getStake().call(opts)
+        return self.deployed.functions.getStake(), opts
 
     def get_price_floor(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getPriceFloor')}, opts)
-        return self.deployed.functions.getPriceFloor().call(opts)
+        return self.deployed.functions.getPriceFloor(), opts
 
     def get_hash(self, param, value, opts=None):
         """
@@ -36,19 +36,19 @@ class Parameterizer(Deployed):
         NOTE: You can likely use web3's `soliditySha3(['uint256', 'uint256'], [p, v])` as well
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('getHash')}, opts)
-        return self.deployed.functions.getHash(param, value).call(opts)
+        return self.deployed.functions.getHash(param, value), opts
 
     def get_spread(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getSpread')}, opts)
-        return self.deployed.functions.getSpread().call(opts)
+        return self.deployed.functions.getSpread(), opts
 
     def get_list_reward(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getListReward')}, opts)
-        return self.deployed.functions.getListReward().call(opts)
+        return self.deployed.functions.getListReward(), opts
 
     def get_plurality(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getPlurality')}, opts)
-        return self.deployed.functions.getPlurality().call(opts)
+        return self.deployed.functions.getPlurality(), opts
 
     def get_reparam(self, hash, opts=None):
         """
@@ -56,16 +56,16 @@ class Parameterizer(Deployed):
         @return (param, value)
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('getReparam')}, opts)
-        return self.deployed.functions.getReparam(hash).call(opts)
+        return self.deployed.functions.getReparam(hash), opts
 
     def get_vote_by(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getVoteBy')}, opts)
-        return self.deployed.functions.getVoteBy().call(opts)
+        return self.deployed.functions.getVoteBy(), opts
 
     def reparameterize(self, param, value, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('reparameterize')}, opts)
-        return self.deployed.functions.reparameterize(param, value).transact(opts)
+        return self.deployed.functions.reparameterize(param, value), opts
 
     def resolveReparam(self, hash, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('resolveReparam')}, opts)
-        return self.deployed.functions.resolveReparam(hash).transact(opts)
+        return self.deployed.functions.resolveReparam(hash), opts

--- a/computable/contracts/voting.py
+++ b/computable/contracts/voting.py
@@ -13,16 +13,16 @@ class Voting(Deployed):
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('setPrivileged')}, opts)
         return self.deployed.functions.setPrivileged(parameterizer, datatrust,
-                listing, investing).transact(opts)
+                listing, investing), opts
 
     def get_privileged(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getPrivileged')}, opts)
-        return self.deployed.functions.getPrivileged().call(opts)
+        return self.deployed.functions.getPrivileged(), opts
 
     def has_privilege(self, addr, opts=None):
         # TODO change the casing when the abi is fixed
         opts = self.assign_transact_opts({'gas': self.get_gas('has_privilege')}, opts)
-        return self.deployed.functions.has_privilege(addr).call(opts)
+        return self.deployed.functions.has_privilege(addr), opts
 
     def candidate_is(self, hash, kind, opts=None):
         """
@@ -30,30 +30,30 @@ class Voting(Deployed):
         @param opts Optional callOpts for this view/constant type call
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('candidateIs')}, opts)
-        return self.deployed.functions.candidateIs(hash, kind).call(opts)
+        return self.deployed.functions.candidateIs(hash, kind), opts
 
     def is_candidate(self, hash, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('isCandidate')}, opts)
-        return self.deployed.functions.isCandidate(hash).call(opts)
+        return self.deployed.functions.isCandidate(hash), opts
 
     def get_candidate(self, hash, opts=None):
         """
         @return (kind, owner, stake, vote_by, yea, nay)
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('getCandidate')}, opts)
-        return self.deployed.functions.getCandidate(hash).call(opts)
+        return self.deployed.functions.getCandidate(hash), opts
 
     def get_candidate_owner(self, hash, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getCandidateOwner')}, opts)
-        return self.deployed.functions.getCandidateOwner(hash).call(opts)
+        return self.deployed.functions.getCandidateOwner(hash), opts
 
     def did_pass(self, hash, plurality, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('didPass')}, opts)
-        return self.deployed.functions.didPass(hash, plurality).call(opts)
+        return self.deployed.functions.didPass(hash, plurality), opts
 
     def poll_closed(self, hash, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('pollClosed')}, opts)
-        return self.deployed.functions.pollClosed(hash).call(opts)
+        return self.deployed.functions.pollClosed(hash), opts
 
     def vote(self, hash, option, opts=None):
         """
@@ -61,7 +61,7 @@ class Voting(Deployed):
         which is translated as a "nay"
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('vote')}, opts)
-        return self.deployed.functions.vote(hash, option).transact(opts)
+        return self.deployed.functions.vote(hash, option), opts
 
     def get_stake(self, hash, addr, opts=None):
         """
@@ -69,11 +69,11 @@ class Voting(Deployed):
         @return Staked amount in wei
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('getStake')}, opts)
-        return self.deployed.functions.getStake(hash, addr).call(opts)
+        return self.deployed.functions.getStake(hash, addr), opts
 
     def unstake(self, hash, opts=None):
         """
         Claim any staked amounts that an address has rights to
         """
         opts = self.assign_transact_opts({'gas': self.get_gas('unstake')}, opts)
-        return self.deployed.functions.unstake(hash).transact(opts)
+        return self.deployed.functions.unstake(hash), opts

--- a/computable/helpers/constants.py
+++ b/computable/helpers/constants.py
@@ -1,1 +1,6 @@
 UNLOCK_DURATION = 600 # default to 10mins
+
+# chain id's
+MAIN_NET = 1
+RINKEBY = 4
+SOKOL = 77

--- a/computable/helpers/transaction.py
+++ b/computable/helpers/transaction.py
@@ -1,0 +1,55 @@
+#  NOTE: Send type transactions have their operations isolated for maximum flexability
+
+#  base_tx, opts = token.approve(addr, amt, opts)
+#  built_tx = build_transaction(w3, base_tx, opts)
+#  signed_tx = sign_transaction(w3, built_tx, private_key)
+#  final_tx = send_raw_transaction(w3, signed_tx)
+
+#  The `send` method abstracts this into a single call, similar to `call` for convenience
+#  tx = send(w3, private_key, token.approve(addr, amt))
+
+def call(args):
+    """
+    Call type operations do not need be signed
+
+    ex:
+    spam = call(token.allowance(addr, addr))
+
+    @param args A tuple which is always [tx, opts]
+    """
+    return args[0].call(args[1])
+
+def transact(args):
+    """
+    If working with unlocked accounts we can simply use the transact method
+    See `call`
+    """
+    return args[0].transact(args[1])
+
+def build_transaction(w3, args):
+    """
+    Return a suitable transaction object for signing.
+    NOTE: We assume the opts object has been prehydrated with a HOC's `assign_transact_opts`
+    """
+    args[1]['nonce'] = w3.eth.getTransactionCount(args[1]['from'])
+    return args[0].buildTransaction(args[1])
+
+def sign_transaction(w3, private_key, tx):
+    """
+    Called after a transaction has been built, perhaps with `build_transaction`
+    """
+    return w3.eth.account.signTransaction(tx, private_key=private_key)
+
+def send_raw_transaction(w3, tx):
+    """
+    Given a signed transaction, broadcast it.
+    """
+    return w3.eth.sendRawTransaction(tx.rawTransaction)
+
+def send(w3, private_key, args):
+    """
+    Convenience method to take a built transaction, sign it and broadcast it using existing methods
+    """
+    built_tx = build_transaction(w3, args)
+    signed_tx = sign_transaction(w3, private_key, built_tx)
+    return send_raw_transaction(w3, signed_tx)

--- a/computable/tests/deployed_base_class_test.py
+++ b/computable/tests/deployed_base_class_test.py
@@ -11,7 +11,8 @@ def base_class(w3):
 def test_assign_transact_opts_empty(base_class):
     defaults = base_class.assign_transact_opts({})
     assert defaults['from'] == base_class.account
-    assert defaults['gas_price'] == GAS_PRICE
+    assert defaults['gasPrice'] == GAS_PRICE
+    assert defaults['chainId'] == None
     assert 'value' not in defaults
 
 def test_assign_transact_opts(base_class):

--- a/computable/tests/ether_token_test.py
+++ b/computable/tests/ether_token_test.py
@@ -2,6 +2,7 @@ import pytest
 import web3
 from web3 import Web3
 from computable.contracts.constants import GAS_BUFFER
+from computable.helpers.transaction import call, transact
 
 def test_deploy(ether_token):
     assert len(ether_token.account) == 42
@@ -9,7 +10,7 @@ def test_deploy(ether_token):
     assert ether_token.account != ether_token.address
 
 def test_initial_balance(ether_token):
-    owner_bal = ether_token.balance_of(ether_token.account)
+    owner_bal = call(ether_token.balance_of(ether_token.account))
     assert owner_bal == Web3.toWei(1, 'ether')
 
 # NOTE: Testing the ERC20 methods in EtherToken in addition to its additional methods
@@ -19,8 +20,8 @@ def test_approve_and_allowance(w3, ether_token):
     assert gas == 37719 + GAS_BUFFER # looked up manually in the abi
     spender = w3.eth.accounts[1]
     # passing empty opts assures all defaults are used
-    tx = ether_token.approve(spender, Web3.toWei(1, 'gwei'))
-    allowed = ether_token.allowance(ether_token.account, w3.eth.accounts[1])
+    tx = transact(ether_token.approve(spender, Web3.toWei(1, 'gwei')))
+    allowed = call(ether_token.allowance(ether_token.account, w3.eth.accounts[1]))
     assert allowed == Web3.toWei(1, 'gwei')
     # check the event
     rct = w3.eth.getTransactionReceipt(tx)
@@ -29,41 +30,41 @@ def test_approve_and_allowance(w3, ether_token):
 
 def test_decrease_approval(w3, ether_token):
     spender = w3.eth.accounts[1]
-    old_allowed = ether_token.allowance(ether_token.account, w3.eth.accounts[1])
-    ether_token.decrease_approval(spender, Web3.toWei(1, 'mwei'), {})
-    new_allowed = ether_token.allowance(ether_token.account, w3.eth.accounts[1])
+    old_allowed = call(ether_token.allowance(ether_token.account, w3.eth.accounts[1]))
+    transact(ether_token.decrease_approval(spender, Web3.toWei(1, 'mwei')))
+    new_allowed = call(ether_token.allowance(ether_token.account, w3.eth.accounts[1]))
     assert new_allowed == old_allowed - Web3.toWei(1, 'mwei')
 
 def test_increase_approval(w3, ether_token):
     spender = w3.eth.accounts[1]
-    old_allowed = ether_token.allowance(ether_token.account, w3.eth.accounts[1])
-    ether_token.increase_approval(spender, Web3.toWei(1, 'kwei'), {})
-    new_allowed = ether_token.allowance(ether_token.account, w3.eth.accounts[1])
+    old_allowed = call(ether_token.allowance(ether_token.account, w3.eth.accounts[1]))
+    transact(ether_token.increase_approval(spender, Web3.toWei(1, 'kwei')))
+    new_allowed = call(ether_token.allowance(ether_token.account, w3.eth.accounts[1]))
     assert new_allowed == old_allowed + Web3.toWei(1, 'kwei')
 
 def test_deposit(w3, ether_token):
     user = w3.eth.accounts[2]
-    user_bal = ether_token.balance_of(user)
+    user_bal = call(ether_token.balance_of(user))
     assert user_bal == 0
     # in normal use cases the user's account would be set, but here we'll just send it
-    ether_token.deposit(Web3.toWei(1, 'gwei'), {'from': user})
-    new_user_bal = ether_token.balance_of(user)
+    transact(ether_token.deposit(Web3.toWei(1, 'gwei'), {'from': user}))
+    new_user_bal = call(ether_token.balance_of(user))
     assert new_user_bal == Web3.toWei(1, 'gwei')
 
 def test_total_supply(ether_token):
-    supply = ether_token.total_supply()
+    supply = call(ether_token.total_supply())
     # don't care what it is, just care it's there
     assert supply > 0
 
 def test_transfer(w3, ether_token):
     user = w3.eth.accounts[3]
-    user_bal = ether_token.balance_of(user)
+    user_bal = call(ether_token.balance_of(user))
     assert user_bal == 0
-    owner_bal = ether_token.balance_of(ether_token.account)
+    owner_bal = call(ether_token.balance_of(ether_token.account))
     # the default account is the initial balance holder here, so that works
-    tx = ether_token.transfer(user, Web3.toWei(1, 'gwei'))
-    new_user_bal = ether_token.balance_of(user)
-    new_owner_bal = ether_token.balance_of(ether_token.account)
+    tx = transact(ether_token.transfer(user, Web3.toWei(1, 'gwei')))
+    new_user_bal = call(ether_token.balance_of(user))
+    new_owner_bal = call(ether_token.balance_of(ether_token.account))
     assert new_user_bal == Web3.toWei(1, 'gwei')
     assert new_owner_bal == owner_bal - Web3.toWei(1, 'gwei')
     # event published...
@@ -73,25 +74,25 @@ def test_transfer(w3, ether_token):
 
 def test_transfer_from(w3, ether_token):
     user = w3.eth.accounts[2]
-    user_bal = ether_token.balance_of(user)
-    owner_bal = ether_token.balance_of(ether_token.account)
+    user_bal = call(ether_token.balance_of(user))
+    owner_bal = call(ether_token.balance_of(ether_token.account))
     amt = Web3.toWei(1, 'mwei')
     # this user needs to approve the 'spender' (the owner in this test case)
-    ether_token.approve(ether_token.account, amt, {'from': user})
+    transact(ether_token.approve(ether_token.account, amt, {'from': user}))
     # with the allowance, that acct may transfer.
-    ether_token.transfer_from(user, ether_token.account, amt)
-    new_user_bal = ether_token.balance_of(user)
-    new_owner_bal = ether_token.balance_of(ether_token.account)
+    transact(ether_token.transfer_from(user, ether_token.account, amt))
+    new_user_bal = call(ether_token.balance_of(user))
+    new_owner_bal = call(ether_token.balance_of(ether_token.account))
     assert new_user_bal == user_bal - amt
     assert new_owner_bal == owner_bal + amt
     # should have 'zeroed' the allowance
-    allowed = ether_token.allowance(user, ether_token.account)
+    allowed = call(ether_token.allowance(user, ether_token.account))
 
 def test_withdraw(w3, ether_token):
     user = w3.eth.accounts[2]
-    user_bal = ether_token.balance_of(user)
-    tx = ether_token.withdraw(user_bal, {'from': user})
-    new_user_bal = ether_token.balance_of(user)
+    user_bal = call(ether_token.balance_of(user))
+    tx = transact(ether_token.withdraw(user_bal, {'from': user}))
+    new_user_bal = call(ether_token.balance_of(user))
     assert new_user_bal == 0
     rct = w3.eth.getTransactionReceipt(tx)
     logs = ether_token.deployed.events.Withdraw().processReceipt(rct)

--- a/computable/tests/market_token_test.py
+++ b/computable/tests/market_token_test.py
@@ -1,6 +1,7 @@
 import pytest
 import web3
 from web3 import Web3
+from computable.helpers.transaction import call
 
 def test_deploy(market_token):
     assert len(market_token.account) == 42
@@ -8,5 +9,5 @@ def test_deploy(market_token):
     assert market_token.account != market_token.address
 
 def test_initial_balance(market_token):
-    owner_bal = market_token.balance_of(market_token.account)
+    owner_bal = call(market_token.balance_of(market_token.account))
     assert owner_bal == Web3.toWei(2, 'ether')

--- a/computable/tests/parameterizer_test.py
+++ b/computable/tests/parameterizer_test.py
@@ -2,6 +2,7 @@ import pytest
 import web3
 from web3 import Web3
 from computable.contracts.constants import SPREAD
+from computable.helpers.transaction import call, transact
 
 
 def test_deploy(parameterizer):
@@ -10,54 +11,54 @@ def test_deploy(parameterizer):
     assert parameterizer.account != parameterizer.address
 
 def test_get_be_pay(parameterizer_opts, parameterizer):
-    pay = parameterizer.get_backend_payment()
+    pay = call(parameterizer.get_backend_payment())
     assert pay == parameterizer_opts['backend_payment']
 
 def test_get_mk_pay(parameterizer_opts, parameterizer):
-    pay = parameterizer.get_maker_payment()
+    pay = call(parameterizer.get_maker_payment())
     assert pay == parameterizer_opts['maker_payment']
 
 def test_get_rs_pay(parameterizer_opts, parameterizer):
-    be = parameterizer.get_backend_payment()
-    mk = parameterizer.get_maker_payment()
-    pay = parameterizer.get_reserve_payment()
+    be = call(parameterizer.get_backend_payment())
+    mk = call(parameterizer.get_maker_payment())
+    pay = call(parameterizer.get_reserve_payment())
     assert pay == 100 - be - mk
 
 def test_get_cost_per(parameterizer_opts, parameterizer):
-    cost = parameterizer.get_cost_per_byte()
+    cost = call(parameterizer.get_cost_per_byte())
     assert cost == parameterizer_opts['cost_per_byte']
 
 def test_get_stake(parameterizer_opts, parameterizer):
-    stake = parameterizer.get_stake()
+    stake = call(parameterizer.get_stake())
     assert stake == parameterizer_opts['stake']
 
 def test_get_price_floor(parameterizer_opts, parameterizer):
-    price = parameterizer.get_price_floor()
+    price = call(parameterizer.get_price_floor())
     assert price == parameterizer_opts['price_floor']
 
 def test_get_price_floor(parameterizer_opts, parameterizer):
-    price = parameterizer.get_price_floor()
+    price = call(parameterizer.get_price_floor())
     assert price == parameterizer_opts['price_floor']
 
 def test_get_hash(parameterizer):
-    hash = parameterizer.get_hash(SPREAD, 115)
+    hash = call(parameterizer.get_hash(SPREAD, 115))
     other_hash = Web3.soliditySha3(['uint256', 'uint256'], [SPREAD, 115])
     assert hash == other_hash
 
 def test_get_spread(parameterizer_opts, parameterizer):
-    spread = parameterizer.get_spread()
+    spread = call(parameterizer.get_spread())
     assert spread == parameterizer_opts['spread']
 
 
 def test_get_list_reward(parameterizer_opts, parameterizer):
-    reward = parameterizer.get_list_reward()
+    reward = call(parameterizer.get_list_reward())
     assert reward == parameterizer_opts['list_reward']
 
 def test_get_plurality(parameterizer_opts, parameterizer):
-    pl = parameterizer.get_plurality()
+    pl = call(parameterizer.get_plurality())
     assert pl == parameterizer_opts['plurality']
 
 
 def test_get_vote_by(parameterizer_opts, parameterizer):
-    end = parameterizer.get_vote_by()
+    end = call(parameterizer.get_vote_by())
     assert end == parameterizer_opts['vote_by']

--- a/computable/tests/parameterizer_voting_integration_test.py
+++ b/computable/tests/parameterizer_voting_integration_test.py
@@ -2,42 +2,43 @@ import pytest
 import web3
 from web3 import Web3
 from computable.contracts.constants import PLURALITY, REPARAM
+from computable.helpers.transaction import call, transact
 
 def test_set_privileged(w3, voting, parameterizer):
     # we can set the real p11r address and 3 imposters for this test
-    priv = voting.has_privilege(parameterizer.address)
+    priv = call(voting.has_privilege(parameterizer.address))
     assert priv == False
     # voting acct is the owner address
-    tx = voting.set_privileged(parameterizer.address, w3.eth.accounts[7],
-            w3.eth.accounts[8], w3.eth.accounts[9])
+    tx = transact(voting.set_privileged(parameterizer.address, w3.eth.accounts[7],
+            w3.eth.accounts[8], w3.eth.accounts[9]))
     # wait for this to be mined
     rct = w3.eth.waitForTransactionReceipt(tx)
-    priv = voting.has_privilege(parameterizer.address)
+    priv = call(voting.has_privilege(parameterizer.address))
     assert priv == True
 
 def test_reparameterize(w3, parameterizer):
-    tx = parameterizer.reparameterize(PLURALITY, 51)
+    tx = transact(parameterizer.reparameterize(PLURALITY, 51))
     rct = w3.eth.waitForTransactionReceipt(tx)
     logs = parameterizer.deployed.events.ReparamProposed().processReceipt(rct)
-    hash = parameterizer.get_hash(PLURALITY, 51)
+    hash = call(parameterizer.get_hash(PLURALITY, 51))
     # should see an event with the calculated hash for those vals
     assert logs[0]['args']['hash'] == hash
 
 def test_is_candidate(voting, parameterizer):
-    hash = parameterizer.get_hash(PLURALITY, 51)
-    is_can = voting.is_candidate(hash)
+    hash = call(parameterizer.get_hash(PLURALITY, 51))
+    is_can = call(voting.is_candidate(hash))
     assert is_can == True
 
 def test_candidate_is(voting, parameterizer):
-    hash = parameterizer.get_hash(PLURALITY, 51)
-    can_is = voting.candidate_is(hash, REPARAM)
+    hash = call(parameterizer.get_hash(PLURALITY, 51))
+    can_is = call(voting.candidate_is(hash, REPARAM))
     assert can_is == True
 
 def test_get_candidate(voting, parameterizer):
-    hash = parameterizer.get_hash(PLURALITY, 51)
-    stake = parameterizer.get_stake()
-    vote_by = parameterizer.get_vote_by()
-    tup = voting.get_candidate(hash)
+    hash = call(parameterizer.get_hash(PLURALITY, 51))
+    stake = call(parameterizer.get_stake())
+    vote_by = call(parameterizer.get_vote_by())
+    tup = call(voting.get_candidate(hash))
     assert tup[0] == REPARAM
     assert tup[1] == parameterizer.account
     assert tup[2] == stake

--- a/computable/tests/voting_test.py
+++ b/computable/tests/voting_test.py
@@ -1,6 +1,7 @@
 import pytest
 import web3
 from web3 import Web3
+from computable.helpers.transaction import call
 
 def test_deploy(voting):
     assert len(voting.account) == 42
@@ -9,8 +10,8 @@ def test_deploy(voting):
 
 def test_is_candidate(voting):
     hash = Web3.sha3(text='nope')
-    assert voting.is_candidate(hash) == False
+    assert call(voting.is_candidate(hash)) == False
 
 def test_candidate_is(voting):
     hash = Web3.sha3(text='stillnope')
-    assert voting.candidate_is(hash, 1) == False
+    assert call(voting.candidate_is(hash, 1)) == False


### PR DESCRIPTION
Pretty fundamental change, but it's easy to grok:
1. HOC methods now return a tuple in the form `(transaction, opts)`
2. This tuple is passed to new helper methods `call(tuple)` or `transact(tuple)`. This way the existing tests are largely unchanged. NOTE: `transact` is for working with unlocked accounts. Not a practice we will encourage but it _is_ a real use case
3. New helpers are created for more _real world_ type signing
* build_transaction
* sign_transaction
* send_raw_transaction

these are all seperated because, depending on the client environment, some steps may be farmed out to things like crypto-sticks...

An upcoming set of specs for locked accounts will be added after this is merged