### PR TITLE
test signing, locking, and a little cleanup

### DIFF
--- a/computable/contracts/deployed.py
+++ b/computable/contracts/deployed.py
@@ -10,8 +10,6 @@ class Deployed:
         class instance
         """
         self.account = acct
-        # default the chain_id to None
-        self.chain_id = None
 
     def assign_transact_opts(self, src, opts=None):
         """
@@ -22,19 +20,16 @@ class Deployed:
             src['from'] = self.account
         if 'gasPrice' not in src:
             src['gasPrice'] = GAS_PRICE
-        if 'chainId' not in src:
-            src['chainId'] = self.chain_id
 
         if opts is not None:
             src.update(opts)
         return src
 
-    def at(self, w3, address, filename, chain_id=None):
+    def at(self, w3, address, filename):
         """
         @param w3 An instance of Web3
         @param address EVM address of a deployed contract
         @param filename Name (with extension) of an abi file to read.
-        @param chain_id Identifier of the block chain `address` is on (or None)
         """
         abi = None
         path = os.path.join(os.path.dirname(__file__), filename)
@@ -52,9 +47,6 @@ class Deployed:
         self.address = address
         # remember the abi so we can fetch gas prices from it
         self.abi = abi
-        # set the passed in chainId if present
-        if chain_id is not None:
-            self.chain_id = chain_id
 
     def get_gas(self, method):
         """

--- a/computable/helpers/account.py
+++ b/computable/helpers/account.py
@@ -1,5 +1,10 @@
 from computable.helpers.constants import UNLOCK_DURATION
 
+def lock(w3, acct=None):
+    if acct is None:
+        acct = w3.eth.defaultAccount
+    return w3.personal.lockAccount(acct)
+
 def unlock(w3, phrase, acct=None, timeout=None):
     """
     @param w3 The current instantiation of Web3
@@ -11,8 +16,3 @@ def unlock(w3, phrase, acct=None, timeout=None):
     if timeout is None:
         timeout = UNLOCK_DURATION
     return w3.personal.unlockAccount(acct, phrase, timeout)
-
-def lock(w3, acct=None):
-    if acct is None:
-        acct = w3.eth.defaultAccount
-    return w3.personal.lockAccount(acct)

--- a/computable/tests/conftest.py
+++ b/computable/tests/conftest.py
@@ -3,6 +3,7 @@ import json
 import pytest
 import web3
 from web3 import Web3
+from eth_keys import keys
 from computable.contracts.constants import SECONDS_IN_A_DAY
 from computable.contracts.ether_token import EtherToken
 from computable.contracts.market_token import MarketToken
@@ -12,6 +13,7 @@ from computable.contracts.investing import Investing
 from computable.contracts.datatrust import Datatrust
 from computable.contracts.listing import Listing
 
+# Web3
 @pytest.fixture(scope='module')
 def test_provider():
     return Web3.EthereumTesterProvider()
@@ -22,6 +24,20 @@ def w3(test_provider):
     instance.eth.defaultAccount = instance.eth.accounts[0] # our test 'owner' account
     return instance
 
+# User (when the default, unlocked accounts will not suffice)
+@pytest.fixture(scope='module')
+def passphrase():
+    return 'spam-eggs-vikings'
+
+@pytest.fixture(scope='module')
+def pk():
+    return keys.PrivateKey(b'\x01' * 32)
+
+@pytest.fixture(scope='module')
+def user(w3, pk, passphrase):
+    return w3.personal.importRawKey(pk.to_hex(), passphrase)
+
+# Contracts
 @pytest.fixture(scope='module')
 def ether_token_opts():
     return {'init_bal': Web3.toWei(1, 'ether')}

--- a/computable/tests/deployed_base_class_test.py
+++ b/computable/tests/deployed_base_class_test.py
@@ -12,7 +12,6 @@ def test_assign_transact_opts_empty(base_class):
     defaults = base_class.assign_transact_opts({})
     assert defaults['from'] == base_class.account
     assert defaults['gasPrice'] == GAS_PRICE
-    assert defaults['chainId'] == None
     assert 'value' not in defaults
 
 def test_assign_transact_opts(base_class):

--- a/computable/tests/lock_unlock_test.py
+++ b/computable/tests/lock_unlock_test.py
@@ -1,0 +1,12 @@
+import pytest
+import web3
+from web3 import Web3
+from computable.helpers.account import lock, unlock
+
+# While we don't recommend using the lock/unlock pattern, the helpers should still work
+def test_lock_account(w3, user):
+    assert lock(w3, user) == True
+
+def test_unlock(w3, passphrase, user):
+    assert unlock(w3, 'not-the-phrase', user) == False
+    assert unlock(w3, passphrase, user) == True

--- a/computable/tests/sign_test.py
+++ b/computable/tests/sign_test.py
@@ -1,0 +1,68 @@
+import pytest
+import web3
+from web3 import Web3
+import computable.helpers.transaction as tx_helpers
+from computable.helpers.account import lock
+from computable.contracts.constants import GAS_PRICE
+
+def test_send_some_eth(w3, user):
+    """
+    our created user account will need a balance in order to do anything
+    """
+    user_bal = w3.eth.getBalance(user)
+    assert user_bal == 0
+    tx = w3.eth.sendTransaction({
+        'from': w3.eth.defaultAccount,
+        'to': user,
+        'gas': 121000,
+        'gasPrice': GAS_PRICE,
+        'value': Web3.toWei(1, 'finney')
+        })
+    rct = w3.eth.waitForTransactionReceipt(tx)
+    new_user_bal = w3.eth.getBalance(user)
+    assert new_user_bal == Web3.toWei(1, 'finney')
+
+def test_send_some_ether_token(w3, user, ether_token):
+    user_bal = tx_helpers.call(ether_token.balance_of(user))
+    assert user_bal == 0
+    tx = tx_helpers.transact(ether_token.transfer(user, Web3.toWei(1, 'gwei')))
+    new_user_bal = tx_helpers.call(ether_token.balance_of(user))
+    assert new_user_bal == Web3.toWei(1, 'gwei')
+
+def test_build_sign_send_transaction(w3, pk, user, ether_token):
+    """
+    transactions may be broken apart into each individual step in order to facilitate various signing
+    methods (like crypto sticks for instance)
+    """
+    lock(w3, user) # assure the account is locked
+    other_user = w3.eth.accounts[1] # we'll send some tokens to this target
+    other_user_bal = tx_helpers.call(ether_token.balance_of(other_user))
+    assert other_user_bal == 0
+    # all computable.py HOC methods return a tuple in the form: (tx, opts)
+    tup = ether_token.transfer(other_user, Web3.toWei(1, 'kwei'), {'from': user})
+    # these may be passed directly to build...
+    built_tx = tx_helpers.build_transaction(w3, tup)
+    assert built_tx['from'] == user
+    # sign it
+    signed_tx = tx_helpers.sign_transaction(w3, pk.to_bytes(), built_tx)
+    assert signed_tx.hash is not None
+    assert signed_tx.r is not None
+    assert signed_tx.s is not None
+    assert signed_tx.v is not None
+    # a signed transaction can then be broadcast
+    final_tx = tx_helpers.send_raw_transaction(w3, signed_tx)
+    rct = w3.eth.waitForTransactionReceipt(final_tx)
+    other_user_new_bal = tx_helpers.call(ether_token.balance_of(other_user))
+    assert other_user_new_bal == Web3.toWei(1, 'kwei')
+
+def test_send(w3, pk, user, ether_token):
+    """
+    we do provide an all-in-one convenience method for offline signing
+    """
+    other_user = w3.eth.accounts[2] # we'll send some tokens to this target
+    other_user_bal = tx_helpers.call(ether_token.balance_of(other_user))
+    assert other_user_bal == 0
+    tx = tx_helpers.send(w3, pk.to_bytes(), ether_token.transfer(other_user, Web3.toWei(1, 'kwei'), {'from': user}))
+    rct = w3.eth.waitForTransactionReceipt(tx)
+    other_user_new_bal = tx_helpers.call(ether_token.balance_of(other_user))
+    assert other_user_new_bal == Web3.toWei(1, 'kwei')


### PR DESCRIPTION
`chainId` is deprecated apparently -- so i took it out as well...