### PR TITLE
Update conftest and add better reserve tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "3.6"
 install:
   - pip install -r requirements.txt
-  - pip install -U web3[tester]
+  - pip install -U web3[tester]==5.0.2
 script:
   - pytest

--- a/computable/contracts/reserve.py
+++ b/computable/contracts/reserve.py
@@ -12,10 +12,10 @@ class Reserve(Deployed):
         opts = self.assign_transact_opts({'gas': self.get_gas('support')}, opts)
         return self.deployed.functions.support(offer), opts
 
-    def get_withdrawal_proceeds(sef, addr, opts=None):
+    def get_withdrawal_proceeds(self, addr, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('getWithdrawalProceeds')}, opts)
         return self.deployed.functions.getWithdrawalProceeds(addr), opts
 
-    def withdraw():
+    def withdraw(self, opts=None):
         opts = self.assign_transact_opts({'gas': self.get_gas('withdraw')}, opts)
         return self.deployed.functions.withdraw(), opts

--- a/computable/tests/parameterizer_voting_integration_test.py
+++ b/computable/tests/parameterizer_voting_integration_test.py
@@ -7,13 +7,6 @@ from computable.helpers.transaction import call, transact
 def test_set_privileged(w3, voting, parameterizer):
     # we can set the real p11r address and 3 imposters for this test
     priv = call(voting.has_privilege(parameterizer.address))
-    assert priv == False
-    # voting acct is the owner address
-    tx = transact(voting.set_privileged(parameterizer.address, w3.eth.accounts[7],
-            w3.eth.accounts[8], w3.eth.accounts[9]))
-    # wait for this to be mined
-    rct = w3.eth.waitForTransactionReceipt(tx)
-    priv = call(voting.has_privilege(parameterizer.address))
     assert priv == True
 
 def test_reparameterize(w3, parameterizer):

--- a/computable/tests/reserve_test.py
+++ b/computable/tests/reserve_test.py
@@ -1,8 +1,118 @@
 import pytest
 import web3
 from web3 import Web3
+from computable.helpers.transaction import call, transact
 
 def test_deploy(reserve):
     assert len(reserve.account) == 42
     assert len(reserve.address) == 42
     assert reserve.account != reserve.address
+
+def test_get_withdrawal_proceeds(reserve):
+   proceeds = call(reserve.get_withdrawal_proceeds(reserve.account))
+   assert proceeds == 0
+
+def test_get_support_price(reserve):
+   support_price = call(reserve.get_support_price())
+   assert support_price == Web3.toWei(1, 'microether')
+
+def test_support(w3, ether_token, market_token, reserve, listing):
+   # Set market token privileges before this test
+   priv = call(market_token.has_privilege(reserve.address))
+   # May have been set previously
+   if priv == False:
+       tx = transact(market_token.set_privileged(reserve.address,
+           listing.address))
+       # wait for this to be mined
+       rct = w3.eth.waitForTransactionReceipt(tx)
+       # Check mining succeeded
+       assert rct['status'] == 1
+       priv = call(market_token.has_privilege(reserve.address))
+       assert priv == True
+
+   user = w3.eth.accounts[2]
+   user_bal = call(ether_token.balance_of(user))
+   assert user_bal == 0
+
+    # Deposit ETH in EtherToken
+   tx = transact(ether_token.deposit(
+       Web3.toWei(1, 'ether'), {'from': user}))
+   rct = w3.eth.waitForTransactionReceipt(tx)
+   new_user_bal = call(ether_token.balance_of(user))
+   assert new_user_bal == Web3.toWei(1, 'ether')
+   assert rct['status'] == 1
+
+    # Approve the spend
+   old_allowance = call(ether_token.allowance(user, reserve.address))
+   assert old_allowance == 0
+   tx= transact(ether_token.approve(reserve.address, Web3.toWei(1, 'ether'), opts={'from': user}))
+   rct = w3.eth.waitForTransactionReceipt(tx)
+   assert rct['status'] == 1
+   new_allowance = call(ether_token.allowance(user, reserve.address))
+   assert new_allowance == Web3.toWei(1, 'ether')
+
+    # Perform pre-checks for support 
+   support_price = call(reserve.get_support_price())
+   assert new_user_bal >= support_price
+   assert new_allowance >= new_user_bal
+   minted = (new_user_bal // support_price) * 10**9
+   assert minted == 10**6 * Web3.toWei(1, 'gwei')
+   priv = call(market_token.has_privilege(reserve.address))
+   assert priv == True
+   total_supply = call(market_token.total_supply())
+   assert total_supply == Web3.toWei(2, 'ether')
+
+    # Call support
+   tx = transact(reserve.support(new_user_bal, opts={'gas': 1000000, 'from': user}))
+   rct = w3.eth.waitForTransactionReceipt(tx)
+   assert rct['status'] == 1
+   logs = reserve.deployed.events.Supported().processReceipt(rct)
+   cmt_user_bal = call(market_token.balance_of(user))
+   assert cmt_user_bal == Web3.toWei(1, 'milliether')
+   new_supply = call(market_token.total_supply())
+   assert new_supply == total_supply + cmt_user_bal
+
+def test_withdraw(w3, ether_token, market_token, reserve, listing):
+   # Set market token privileges before this test
+   priv = call(market_token.has_privilege(reserve.address))
+   # It's possible the privilege may have been set already
+   if priv == False:
+       tx = transact(market_token.set_privileged(reserve.address,
+           listing.address))
+       # wait for this to be mined
+       rct = w3.eth.waitForTransactionReceipt(tx)
+       # Check mining succeeded
+       assert rct['status'] == 1
+       priv = call(market_token.has_privilege(reserve.address))
+       assert priv == True
+   # Use a new user
+   user = w3.eth.accounts[3]
+   tx = transact(ether_token.deposit(
+       Web3.toWei(1, 'ether'), {'from': user}))
+   rct = w3.eth.waitForTransactionReceipt(tx)
+   new_user_bal = call(ether_token.balance_of(user))
+   assert new_user_bal == Web3.toWei(1, 'ether')
+
+    # Approve the spend
+   tx= transact(ether_token.approve(reserve.address, Web3.toWei(1, 'ether'), opts={'from': user}))
+   rct = w3.eth.waitForTransactionReceipt(tx)
+   assert rct['status'] == 1
+
+    # Call support
+   tx = transact(reserve.support(new_user_bal, opts={'gas': 1000000, 'from': user}))
+   rct = w3.eth.waitForTransactionReceipt(tx)
+   assert rct['status'] == 1
+   cmt_user_bal = call(market_token.balance_of(user))
+   # This is around one milliether, but not quite due to spread
+   assert cmt_user_bal > 0 
+
+    # Call withdraw 
+   tx = transact(reserve.withdraw(opts={'gas': 1000000, 'from': user}))
+   rct = w3.eth.waitForTransactionReceipt(tx)
+   assert rct['status'] == 1
+   cmt_user_bal = call(market_token.balance_of(user))
+   # This should be 0 
+   assert cmt_user_bal == 0 
+   cet_user_bal = call(ether_token.balance_of(user))
+   # Should be a little under 1 eth
+   assert cet_user_bal > 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-web3==5.0.0b2
+web3==5.0.2
 eth-tester==0.1.0b39
-pytest==4.4.1
+pytest==5.1.2


### PR DESCRIPTION
This PR:

- Updates `conftest.py` to match CAPI's conftest (in particular sets privilege properly for test suite contracts)
- Fixes typos in reserve and adds tests (folded in from #21)